### PR TITLE
Compare status messages in a case-insensitive manner

### DIFF
--- a/send.sh
+++ b/send.sh
@@ -12,6 +12,7 @@ echo -e "[Webhook]: Sending webhook to Discord...\\n";
 
 AVATAR="https://github.com/actions.png"
 
+# More info: https://www.gnu.org/software/bash/manual/bash.html#Shell-Parameter-Expansion
 case ${1,,} in
   "success" )
     EMBED_COLOR=3066993

--- a/send.sh
+++ b/send.sh
@@ -12,13 +12,13 @@ echo -e "[Webhook]: Sending webhook to Discord...\\n";
 
 AVATAR="https://github.com/actions.png"
 
-case $1 in
-  "Success" )
+case ${1,,} in
+  "success" )
     EMBED_COLOR=3066993
     STATUS_MESSAGE="Passed"
     ;;
 
-  "Failure" )
+  "failure" )
     EMBED_COLOR=15158332
     STATUS_MESSAGE="Failed"
     ;;


### PR DESCRIPTION
Closes #13. 

This fix requires Bash 4.0, I don't think any GitHub actions runners use anything older than that so this should be mergeable without any breakage. 